### PR TITLE
Relax scipy version requirement and update python version requirement to >=3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "freegs4e"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     {name = "The FreeGS4E and FreeGS developers"}
 ]
 description = "Free boundary tokamak plasma equilibrium Grad-Shafranov solver for time evolution"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy<2.0
-scipy~=1.14
+scipy~=1.9
 matplotlib~=3.0
 h5py~=3.11
 numba~=0.60


### PR DESCRIPTION
The scipy version requirement was preventing installation of FreeGSNKE for Python v3.9.