### PR TITLE
added geometric perpendicular by xpoint to insidemask to avoid flooding cases

### DIFF
--- a/freegs4e/critical.py
+++ b/freegs4e/critical.py
@@ -609,7 +609,7 @@ def inside_mask_(
     psi_bndry=None,
 ):
     """
-    Similar to core_mask_old above, except:
+    Similar to the original FreeGS core_mask above, except:
     (1) it's all stuff that can be JIT-compiled
     (2) some stuff is vectorised
     (3) the stack does not necessarily explore in only one direction, and it should be neat around the X-points
@@ -691,6 +691,9 @@ def inside_mask(
     psi_bndry=None,
     use_geom=True,
 ):
+    """Full identification of the diverted plasma core mask. 
+    Combines inside_mask_ and geom_inside_mask.
+    """
     mask = inside_mask_(
         R, Z, psi, opoint, xpoint, mask_outside_limiter, psi_bndry
     )

--- a/freegs4e/critical.py
+++ b/freegs4e/critical.py
@@ -600,7 +600,13 @@ def core_mask(R, Z, psi, opoint, xpoint=[], psi_bndry=None):
 
 @njit(fastmath=True, cache=True)
 def inside_mask_(
-    R, Z, psi, opoint, xpoint=[], mask_outside_limiter=None, psi_bndry=None, 
+    R,
+    Z,
+    psi,
+    opoint,
+    xpoint=[],
+    mask_outside_limiter=None,
+    psi_bndry=None,
 ):
     """
     Similar to core_mask_old above, except:
@@ -670,15 +676,24 @@ def inside_mask_(
     #
 
     # remove effect of mask_outside_limiter
-    mask = (mask == 1)
+    mask = mask == 1
 
     return mask
 
+
 def inside_mask(
-    R, Z, psi, opoint, xpoint=[], mask_outside_limiter=None, psi_bndry=None, use_geom=True,
+    R,
+    Z,
+    psi,
+    opoint,
+    xpoint=[],
+    mask_outside_limiter=None,
+    psi_bndry=None,
+    use_geom=True,
 ):
     mask = inside_mask_(
-    R, Z, psi, opoint, xpoint, mask_outside_limiter, psi_bndry)
+        R, Z, psi, opoint, xpoint, mask_outside_limiter, psi_bndry
+    )
     if use_geom:
         # cure flooding
         mask = mask * geom_inside_mask(R, Z, opoint, xpoint)
@@ -694,14 +709,16 @@ def geom_inside_mask(R, Z, opoint, xpoint):
     inside_mask - mask returned by inside_mask function
     opoint, xpoint  - Values returned by find_critical
     """
-    
-    slope = -(opoint[0,0]-xpoint[0,0])/(opoint[0,1]-xpoint[0,1])
-    interc = xpoint[0,1] - slope*xpoint[0,0]
 
-    geom_mask = ((opoint[0,1] - (slope*opoint[0,0]+interc))*(Z - (slope*R+interc)))>0
+    slope = -(opoint[0, 0] - xpoint[0, 0]) / (opoint[0, 1] - xpoint[0, 1])
+    interc = xpoint[0, 1] - slope * xpoint[0, 0]
+
+    geom_mask = (
+        (opoint[0, 1] - (slope * opoint[0, 0] + interc))
+        * (Z - (slope * R + interc))
+    ) > 0
 
     return geom_mask
-
 
 
 def find_psisurface(eq, psifunc, r0, z0, r1, z1, psival=1.0, n=100, axis=None):

--- a/freegs4e/critical.py
+++ b/freegs4e/critical.py
@@ -599,8 +599,8 @@ def core_mask(R, Z, psi, opoint, xpoint=[], psi_bndry=None):
 
 
 @njit(fastmath=True, cache=True)
-def inside_mask(
-    R, Z, psi, opoint, xpoint=[], mask_outside_limiter=None, psi_bndry=None
+def inside_mask_(
+    R, Z, psi, opoint, xpoint=[], mask_outside_limiter=None, psi_bndry=None, 
 ):
     """
     Similar to core_mask_old above, except:
@@ -670,9 +670,38 @@ def inside_mask(
     #
 
     # remove effect of mask_outside_limiter
-    mask = mask == 1
+    mask = (mask == 1)
 
     return mask
+
+def inside_mask(
+    R, Z, psi, opoint, xpoint=[], mask_outside_limiter=None, psi_bndry=None, use_geom=True,
+):
+    mask = inside_mask_(
+    R, Z, psi, opoint, xpoint, mask_outside_limiter, psi_bndry)
+    if use_geom:
+        # cure flooding
+        mask = mask * geom_inside_mask(R, Z, opoint, xpoint)
+    return mask
+
+
+def geom_inside_mask(R, Z, opoint, xpoint):
+    """Excludes regions based on perpendicular to segment
+    from O-point to primary X-point
+
+    Parameters
+    ----------
+    inside_mask - mask returned by inside_mask function
+    opoint, xpoint  - Values returned by find_critical
+    """
+    
+    slope = -(opoint[0,0]-xpoint[0,0])/(opoint[0,1]-xpoint[0,1])
+    interc = xpoint[0,1] - slope*xpoint[0,0]
+
+    geom_mask = ((opoint[0,1] - (slope*opoint[0,0]+interc))*(Z - (slope*R+interc)))>0
+
+    return geom_mask
+
 
 
 def find_psisurface(eq, psifunc, r0, z0, r1, z1, psival=1.0, n=100, axis=None):

--- a/freegs4e/critical.py
+++ b/freegs4e/critical.py
@@ -691,7 +691,7 @@ def inside_mask(
     psi_bndry=None,
     use_geom=True,
 ):
-    """Full identification of the diverted plasma core mask. 
+    """Full identification of the diverted plasma core mask.
     Combines inside_mask_ and geom_inside_mask.
     """
     mask = inside_mask_(


### PR DESCRIPTION
function inside_mask in critical now also uses perpendicular to the segment between O-point and X-point to avoid flooding of the core mask through the X-point