### PR TITLE
Correct N+1 term in Lao profile parameterisation

### DIFF
--- a/freegs4e/jtor.py
+++ b/freegs4e/jtor.py
@@ -923,16 +923,20 @@ class Lao85(Profile):
 
         # Set parameters for later use
         self.alpha = np.array(alpha)
+        self.alpha_exp = np.arange(0, len(self.alpha))
         self.alpha_logic = alpha_logic
         if alpha_logic:
             self.alpha = np.concatenate((self.alpha, [-np.sum(self.alpha)]))
-        self.alpha_exp = np.arange(0, len(self.alpha))
+            self.alpha_exp = np.concatenate(
+                (self.alpha_exp, [len(self.alpha)])
+            )
 
         self.beta = np.array(beta)
+        self.beta_exp = np.arange(0, len(self.beta))
         self.beta_logic = beta_logic
         if beta_logic:
             self.beta = np.concatenate((self.beta, [-np.sum(self.beta)]))
-        self.beta_exp = np.arange(0, len(self.beta))
+            self.beta_exp = np.concatenate((self.beta_exp, [len(self.beta)]))
 
         self.Ip = Ip
         self.Ip_logic = Ip_logic


### PR DESCRIPTION
Lao _et al._ [1] provides the following flux function parameterisations:

![image](https://github.com/user-attachments/assets/44f287fa-ec4c-495b-ae75-122f4191e999)


The alpha and beta constant indexing starts at $0$. Lao explicitly mentions, for the example of $\mathbf{\alpha} = [\alpha_0, \alpha_1, \alpha_2]$, that $n_p = 3$. As a consequence, the final $x$ (normalised $\psi$) term should be to the power of 4, not 3 (as in the current implementation). (A somewhat relevant note is that the sums are exclusive of $n_p$ (or $n_f$)).

The current implementation places the final $\psi$ term to the power of $n_p$, and not $n_p + 1$ as is prescribed by the paper. This PR changes that.


[1] Lao, L. L., et al. "Reconstruction of current profile parameters and plasma shapes in tokamaks." Nuclear fusion 25.11 (1985): 1611.